### PR TITLE
Fix rake

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,5 @@
 class Customer < ApplicationRecord
   validates :first_name, :last_name, presence: true
 
-  has_many :invoices, dependent: :nullify
+  has_many :invoices, dependent: :destroy
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,5 @@
 class Customer < ApplicationRecord
   validates :first_name, :last_name, presence: true
 
-  has_many :invoices
+  has_many :invoices, dependent: :nullify
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,9 +1,9 @@
 class Invoice < ApplicationRecord
   validates :status, presence: true
 
-  belongs_to :customer, dependent: :nullify
-  has_many :transactions, dependent: :nullify
-  has_many :invoice_items, dependent: :nullify
+  belongs_to :customer, dependent: :destroy
+  has_many :transactions, dependent: :destroy
+  has_many :invoice_items, dependent: :destroy
   has_many :items, through: :invoice_items
-  belongs_to :merchant, dependent: :nullify
+  belongs_to :merchant, dependent: :destroy
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,9 +1,9 @@
 class Invoice < ApplicationRecord
   validates :status, presence: true
 
-  belongs_to :customer
-  has_many :transactions
-  has_many :invoice_items
+  belongs_to :customer, dependent: :nullify
+  has_many :transactions, dependent: :nullify
+  has_many :invoice_items, dependent: :nullify
   has_many :items, through: :invoice_items
-  belongs_to :merchant
+  belongs_to :merchant, dependent: :nullify
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,6 +1,6 @@
 class InvoiceItem < ApplicationRecord
   validates :quantity, :unit_price, presence: true
 
-  belongs_to :invoice
-  belongs_to :item
+  belongs_to :invoice, dependent: :nullify
+  belongs_to :item, dependent: :nullify
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,6 +1,6 @@
 class InvoiceItem < ApplicationRecord
   validates :quantity, :unit_price, presence: true
 
-  belongs_to :invoice, dependent: :nullify
-  belongs_to :item, dependent: :nullify
+  belongs_to :invoice, dependent: :destroy
+  belongs_to :item, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   validates :name, :description, :unit_price, presence: true
 
-  belongs_to :merchant
-  has_many :invoice_items
+  belongs_to :merchant, dependent: :nullify
+  has_many :invoice_items, dependent: :nullify
   has_many :invoices, through: :invoice_items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   validates :name, :description, :unit_price, presence: true
 
-  belongs_to :merchant, dependent: :nullify
-  has_many :invoice_items, dependent: :nullify
+  belongs_to :merchant, dependent: :destroy
+  has_many :invoice_items, dependent: :destroy
   has_many :invoices, through: :invoice_items
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,7 @@
 class Merchant < ApplicationRecord
   validates :name, presence: true
 
-  has_many :items
-  has_many :invoices
+  has_many :items, dependent: :nullify
+  has_many :invoices, dependent: :nullify
   has_many :transactions, through: :invoices
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,7 @@
 class Merchant < ApplicationRecord
   validates :name, presence: true
 
-  has_many :items, dependent: :nullify
-  has_many :invoices, dependent: :nullify
+  has_many :items, dependent: :destroy
+  has_many :invoices, dependent: :destroy
   has_many :transactions, through: :invoices
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,5 @@
 class Transaction < ApplicationRecord
   validates :credit_card_number, :result, presence: true
 
-  belongs_to :invoice, dependent: :nullify
+  belongs_to :invoice, dependent: :destroy
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,5 @@
 class Transaction < ApplicationRecord
   validates :credit_card_number, :result, presence: true
 
-  belongs_to :invoice
+  belongs_to :invoice, dependent: :nullify
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,5 @@
 class Transaction < ApplicationRecord
-  validates :credit_card_number, :credit_card_expiration_date, :result, presence: true
+  validates :credit_card_number, :result, presence: true
 
   belongs_to :invoice
 end

--- a/lib/tasks/import_csvs.rake
+++ b/lib/tasks/import_csvs.rake
@@ -3,7 +3,6 @@ require 'csv'
 desc 'Import data from csv files'
 task :import => [:environment] do
 
-  system 'rake db:reset > /dev/nul'
   puts 'Clearing database...'
   Transaction.destroy_all
   InvoiceItem.destroy_all
@@ -13,32 +12,20 @@ task :import => [:environment] do
   Customer.destroy_all
 
   puts 'Importing customers...'
-  CSV.foreach('./db/data/customers.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    Customer.create(row.to_h)
+  CSV.foreach('./db/data/customers.csv', headers: true, header_converters: :symbol) do |row|
+    Customer.create!(row.to_h)
   end
+  puts "#{Customer.count} Customers created"
 
-  puts 'Importing invoice items...'
-  CSV.foreach('./db/data/invoice_items.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    InvoiceItem.create({
-      id: row[:id],
-      item_id: row[:item_id],
-      invoice_id: row[:invoice_id],
-      quantity: row[:quantity],
-      unit_price: row[:unit_price].to_f/100,
-      created_at: row[:created_at],
-      updated_at: row[:updated_at]
-      }
-    )
+  puts 'Importing merchants...'
+  CSV.foreach('./db/data/merchants.csv', headers: true, header_converters: :symbol) do |row|
+    Merchant.create!(row.to_h)
   end
-
-  puts 'Importing invoices...'
-  CSV.foreach('./db/data/invoices.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    Invoice.create(row.to_h)
-  end
+  puts "#{Merchant.count} Merchants created"
 
   puts 'Importing items...'
-  CSV.foreach('./db/data/items.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    Item.create({
+  CSV.foreach('./db/data/items.csv', headers: true, header_converters: :symbol) do |row|
+    Item.create!({
         id: row[:id],
         name: row[:name],
         description: row[:description],
@@ -49,20 +36,38 @@ task :import => [:environment] do
       }
     )
   end
+  puts "#{Item.count} Items created"
 
-  puts 'Importing merchants...'
-  CSV.foreach('./db/data/merchants.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    Merchant.create(row.to_h)
+  puts 'Importing invoices...'
+  CSV.foreach('./db/data/invoices.csv', headers: true, header_converters: :symbol) do |row|
+    Invoice.create!(row.to_h)
   end
+  puts "#{Invoice.count} Invoices created"
+
+  puts 'Importing invoice items...'
+  CSV.foreach('./db/data/invoice_items.csv', headers: true, header_converters: :symbol) do |row|
+    InvoiceItem.create!({
+      id: row[:id],
+      item_id: row[:item_id],
+      invoice_id: row[:invoice_id],
+      quantity: row[:quantity],
+      unit_price: row[:unit_price].to_f/100,
+      created_at: row[:created_at],
+      updated_at: row[:updated_at]
+      }
+    )
+  end
+  puts "#{InvoiceItem.count} InvoiceItems created"
 
   puts 'Importing transactions...'
-  CSV.foreach('./db/data/transactions.csv', headers: true, header_converters: :symbol, convert: :all) do |row|
-    Transaction.create(row.to_h)
+  CSV.foreach('./db/data/transactions.csv', headers: true, header_converters: :symbol) do |row|
+    Transaction.create!(row.to_h)
   end
+  puts "#{Transaction.count} Transactions created"
 
-  ActiveRecord::Base.connection.tables.each do |t|
-    ActiveRecord::Base.connection.reset_pk_sequence!(t)
+  if Customer.count == 1000 && Merchant.count == 100 && Item.count == 2483 && Invoice.count == 4843 && InvoiceItem == 21687 && Transaction.count == 5595
+    puts "CSV successfully imported into database"
+  else
+    puts "CSV was not successfully imported into database"
   end
-
-  puts "CSV successfully imported into database"
 end

--- a/spec/models/tracnsaction_spec.rb
+++ b/spec/models/tracnsaction_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Transaction, type: :model do
   describe 'validations' do
     it { should validate_presence_of :credit_card_number }
-    it { should validate_presence_of :credit_card_expiration_date }
     it { should validate_presence_of :result }
   end
 


### PR DESCRIPTION
close #4 

Fix bug that wasn't allowing rake file to seed all of the databases.

The issue was with the order by which the objects were created. 
They had to be created in an order where the foreign key references for that object had to already be created in order for it to be created. 

Rake task seeding has to happen in this order:

Customer -> Merchant -> Item -> Invoice -> InvoiceItem -> Transaction