### PR TITLE
Add merchant and item request serialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'figaro'
 gem 'rubocop-rails'
 gem 'faker'
+gem 'fast_jsonapi'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -210,6 +212,7 @@ DEPENDENCIES
   capybara
   factory_bot_rails
   faker
+  fast_jsonapi
   figaro
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,23 +1,23 @@
 class Api::V1::ItemsController < ApplicationController
   def index
-    render json: Item.all
+    render json: ItemSerializer.new(Item.all)
   end
 
   def show
-    render json: Item.find(params[:id])
+    render json: ItemSerializer.new(Item.find(params[:id]))
   end
 
   def create
     merchant = Merchant.find(params[:item][:merchant_id])
-    render json: merchant.items.create!(item_params)
+    render json: ItemSerializer.new(merchant.items.create!(item_params))
   end
 
   def update
-    render json: Item.update(params[:id], item_params)
+    render json: ItemSerializer.new(Item.update(params[:id], item_params))
   end
 
   def destroy
-    Item.destroy(params[:id])
+    render json: ItemSerializer.new(Item.destroy(params[:id]))
   end
 
   private

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,22 +1,22 @@
 class Api::V1::MerchantsController < ApplicationController
   def index
-    render json: Merchant.all
+    render json: MerchantSerializer.new(Merchant.all)
   end
 
   def show
-    render json: Merchant.find(params[:id])
+    render json: MerchantSerializer.new(Merchant.find(params[:id]))
   end
 
   def create
-    render json: Merchant.create!(merchant_params)
+    render json: MerchantSerializer.new(Merchant.create!(merchant_params))
   end
 
   def update
-    render json: Merchant.update(params[:id], merchant_params)
+    render json: MerchantSerializer.new(Merchant.update(params[:id], merchant_params))
   end
 
   def destroy
-    render json: Merchant.destroy(params[:id])
+    render json: MerchantSerializer.new(Merchant.destroy(params[:id]))
   end
 
   private

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,4 @@
+class ItemSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :description, :unit_price
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,4 @@
+class MerchantSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,12 @@ Rails.application.routes.draw do
       resources :merchants, only: [:index, :show, :create, :update, :destroy]
     end
   end
+
+  # namespace :api do
+  #   namespace :v1 do
+  #     namespace :merchants do
+  #       get '/find', to: 'search#'
+  #     end
+  #   end
+  # end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -5,17 +5,16 @@ RSpec.describe 'Items API' do
     create_list(:item, 3)
 
     get '/api/v1/items'
+    items_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
-
-    items = JSON.parse(response.body, symbolize_names: true)
-
-    expect(items[:data].size).to eq(3)
-    expect(items[:data][0]).to have_key(:id)
-    expect(items[:data][0]).to have_key(:type)
-    expect(items[:data][0][:attributes]).to have_key(:name)
-    expect(items[:data][0][:attributes]).to have_key(:description)
-    expect(items[:data][0][:attributes]).to have_key(:unit_price)
+    expect(items_json.class).to eq(Hash)
+    expect(items_json[:data].size).to eq(3)
+    expect(items_json[:data][0]).to have_key(:id)
+    expect(items_json[:data][0]).to have_key(:type)
+    expect(items_json[:data][0][:attributes]).to have_key(:name)
+    expect(items_json[:data][0][:attributes]).to have_key(:description)
+    expect(items_json[:data][0][:attributes]).to have_key(:unit_price)
   end
 
   it "can get item by its id" do
@@ -26,6 +25,7 @@ RSpec.describe 'Items API' do
     item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(item_json.class).to eq(Hash)
     expect(item_json[:data][:id]).to eq("#{item.id}")
     expect(item_json[:data][:type]).to eq('item')
     expect(item_json[:data][:attributes][:name]).to eq(item.name)
@@ -42,6 +42,7 @@ RSpec.describe 'Items API' do
     item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(item_json.class).to eq(Hash)
     expect(item.name).to eq(item_params[:name])
     expect(item_json[:data][:id]).to eq("#{item.id}")
     expect(item_json[:data][:type]).to eq('item')
@@ -61,6 +62,7 @@ RSpec.describe 'Items API' do
     item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(item_json.class).to eq(Hash)
     expect(item.name).to_not eq(previous_name)
     expect(item.name).to eq(item_params[:name])
     expect(item_json[:data][:id]).to eq("#{id}")
@@ -76,8 +78,9 @@ RSpec.describe 'Items API' do
     expect(Item.count).to eq(1)
     expect{ delete "/api/v1/items/#{item.id}" }.to change(Item, :count).by(-1)
     item_json = JSON.parse(response.body, symbolize_names: true)
-    
+
     expect(response).to be_successful
+    expect(item_json.class).to eq(Hash)
     expect(item_json[:data][:id]).to eq("#{item.id}")
     expect(item_json[:data][:type]).to eq('item')
     expect(item_json[:data][:attributes][:name]).to eq(item.name)

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -8,20 +8,29 @@ RSpec.describe 'Items API' do
 
     expect(response).to be_successful
 
-    items = JSON.parse(response.body)
+    items = JSON.parse(response.body, symbolize_names: true)
 
-    expect(items.count).to eq(3)
+    expect(items[:data].size).to eq(3)
+    expect(items[:data][0]).to have_key(:id)
+    expect(items[:data][0]).to have_key(:type)
+    expect(items[:data][0][:attributes]).to have_key(:name)
+    expect(items[:data][0][:attributes]).to have_key(:description)
+    expect(items[:data][0][:attributes]).to have_key(:unit_price)
   end
 
   it "can get item by its id" do
-    id = create(:item).id
+    item = create(:item)
 
-    get "/api/v1/items/#{id}"
+    get "/api/v1/items/#{item.id}"
 
-    item = JSON.parse(response.body)
+    item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
-    expect(item['id']).to eq(id)
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item.name)
+    expect(item_json[:data][:attributes][:description]).to eq(item.description)
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item.unit_price)
   end
 
   it "can create a new item" do
@@ -30,9 +39,16 @@ RSpec.describe 'Items API' do
 
     post '/api/v1/items', params: {item: item_params}
     item = Item.last
+    item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
     expect(item.name).to eq(item_params[:name])
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item_params[:name])
+    expect(item_json[:data][:attributes][:description]).to eq(item_params[:description])
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item_params[:unit_price])
+
   end
 
   it "can update an exisiting item" do
@@ -42,10 +58,16 @@ RSpec.describe 'Items API' do
 
     patch "/api/v1/items/#{id}", params: { item: item_params }
     item = Item.find(id)
+    item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
     expect(item.name).to_not eq(previous_name)
-    expect(item.name).to eq('Sledge')
+    expect(item.name).to eq(item_params[:name])
+    expect(item_json[:data][:id]).to eq("#{id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item_params[:name])
+    expect(item_json[:data][:attributes][:description]).to eq(item.description)
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item.unit_price)
   end
 
   it "can destroy an item" do
@@ -53,7 +75,14 @@ RSpec.describe 'Items API' do
 
     expect(Item.count).to eq(1)
     expect{ delete "/api/v1/items/#{item.id}" }.to change(Item, :count).by(-1)
+    item_json = JSON.parse(response.body, symbolize_names: true)
+    
     expect(response).to be_successful
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item.name)
+    expect(item_json[:data][:attributes][:description]).to eq(item.description)
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item.unit_price)
     expect(Item.count).to eq(0)
     expect{Item.find(item.id)}.to raise_error(ActiveRecord::RecordNotFound)
   end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe 'Merchant API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)
+    merchants = JSON.parse(response.body, symbolize_names: true)
 
-    expect(merchants.count).to eq(3)
+    expect(merchants[:data].size).to eq(3)
+    expect(merchants[:data][0]).to have_key(:id)
+    expect(merchants[:data][0]).to have_key(:type)
+    expect(merchants[:data][0]).to have_key(:attributes)
+    expect(merchants[:data][0][:attributes]).to have_key(:name)
   end
 
   it "can find a merchant" do
@@ -18,10 +22,14 @@ RSpec.describe 'Merchant API' do
 
     get "/api/v1/merchants/#{id}"
 
-    merchant = JSON.parse(response.body)
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+    merchant = Merchant.find(id)
 
     expect(response).to be_successful
-    expect(merchant['id']).to eq(id)
+    expect(merchant_json[:data][:id]).to eq("#{id}")
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+
   end
 
   it "can create a merchant" do
@@ -29,9 +37,13 @@ RSpec.describe 'Merchant API' do
 
     post '/api/v1/merchants', params: { merchant: merchant_params }
     merchant = Merchant.last
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
     expect(merchant.name).to eq(merchant_params[:name])
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
   end
 
   it "can update a merchant" do
@@ -41,19 +53,28 @@ RSpec.describe 'Merchant API' do
 
     patch "/api/v1/merchants/#{id}", params: { merchant: merchant_params }
     merchant = Merchant.find(id)
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
     expect(merchant.name).to_not eq(previous_name)
     expect(merchant.name).to eq(merchant_params[:name])
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant_params[:name])
   end
 
   it "can destroy a merchant" do
-    merchant_id = create(:merchant).id
+    merchant = create(:merchant)
 
     expect(Merchant.count).to eq(1)
-    expect{ delete "/api/v1/merchants/#{merchant_id}" }.to change(Merchant, :count).by(-1)
+    expect{ delete "/api/v1/merchants/#{merchant.id}" }.to change(Merchant, :count).by(-1)
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+
     expect(response).to be_successful
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
     expect(Merchant.count).to eq(0)
-    expect{Merchant.find(merchant_id)}.to raise_error(ActiveRecord::RecordNotFound)
+    expect{Merchant.find(merchant.id)}.to raise_error(ActiveRecord::RecordNotFound)
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe 'Merchant API' do
 
     get '/api/v1/merchants'
 
+    merchants_json = JSON.parse(response.body, symbolize_names: true)
+
     expect(response).to be_successful
-
-    merchants = JSON.parse(response.body, symbolize_names: true)
-
-    expect(merchants[:data].size).to eq(3)
-    expect(merchants[:data][0]).to have_key(:id)
-    expect(merchants[:data][0]).to have_key(:type)
-    expect(merchants[:data][0]).to have_key(:attributes)
-    expect(merchants[:data][0][:attributes]).to have_key(:name)
+    expect(merchants_json.class).to eq(Hash)
+    expect(merchants_json[:data].size).to eq(3)
+    expect(merchants_json[:data][0]).to have_key(:id)
+    expect(merchants_json[:data][0]).to have_key(:type)
+    expect(merchants_json[:data][0]).to have_key(:attributes)
+    expect(merchants_json[:data][0][:attributes]).to have_key(:name)
   end
 
   it "can find a merchant" do
@@ -26,6 +26,7 @@ RSpec.describe 'Merchant API' do
     merchant = Merchant.find(id)
 
     expect(response).to be_successful
+    expect(merchant_json.class).to eq(Hash)
     expect(merchant_json[:data][:id]).to eq("#{id}")
     expect(merchant_json[:data][:type]).to eq('merchant')
     expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
@@ -40,6 +41,7 @@ RSpec.describe 'Merchant API' do
     merchant_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(merchant_json.class).to eq(Hash)
     expect(merchant.name).to eq(merchant_params[:name])
     expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
     expect(merchant_json[:data][:type]).to eq('merchant')
@@ -56,6 +58,7 @@ RSpec.describe 'Merchant API' do
     merchant_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(merchant_json.class).to eq(Hash)
     expect(merchant.name).to_not eq(previous_name)
     expect(merchant.name).to eq(merchant_params[:name])
     expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
@@ -71,6 +74,7 @@ RSpec.describe 'Merchant API' do
     merchant_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+    expect(merchant_json.class).to eq(Hash)
     expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
     expect(merchant_json[:data][:type]).to eq('merchant')
     expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)


### PR DESCRIPTION
Closing #10 #9 #8 

Merging [serialization](https://github.com/Kathybui732/rails_engine/tree/serialization) into [master](https://github.com/Kathybui732/rails_engine/tree/master)

Features added:
- Added gem 'fast_jsonapi' to Gemfile and bundle install
- Updated tests to test for a hash-like json response
- Created serialization of items and merchant by creating a serializer for both
- Updated controllers to call i.e. ItemSerilizer.new(items collection or item) to return json responses